### PR TITLE
Change Analysis Mode Semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ hbat input.pdb --json results     # Creates results_h_bonds.json, results_x_bond
 With custom parameters:
 
 ```bash
-hbat input.pdb -o results.txt --hb-distance 3.0 --mode local
+hbat input.pdb -o results.txt --hb-distance 3.0 --mode inter
 ```
 
 #### List Available Presets
@@ -279,8 +279,10 @@ Analysis Parameters:
   General Parameters:
   --covalent-factor COVALENT_FACTOR
                         Covalent bond detection factor (default: 0.85)
-  --mode {complete,local}
-                        Analysis mode: complete (all interactions) or local (intra-residue only)
+  --mode {inter,all}
+                        Interaction inclusion mode: inter includes interactions
+                        between different residues only; all also includes
+                        intra-residue interactions
 
 Output Control:
   --verbose, -v         Verbose output with detailed progress

--- a/README.md
+++ b/README.md
@@ -192,6 +192,16 @@ With custom parameters:
 hbat input.pdb -o results.txt --hb-distance 3.0 --mode inter
 ```
 
+Interaction inclusion modes:
+
+| Mode | Inter-residue | Intra-residue |
+|---|---:|---:|
+| `inter` | Yes | No |
+| `all` | Yes | Yes |
+
+> **Breaking change:** The previous `local` and `complete` mode values are no
+> longer valid. Replace `local` with `inter` and `complete` with `all`.
+
 #### List Available Presets
 
 ```bash

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -178,12 +178,12 @@ General Parameters
    Covalent bond detection factor (default: 0.85). This factor is multiplied
    with the sum of covalent radii to determine if atoms are covalently bonded.
 
-.. option:: --mode {complete,local}
+.. option:: --mode {inter,all}
 
-   Analysis mode:
+   Interaction inclusion mode:
 
-   - ``complete``: Analyze all interactions (default)
-   - ``local``: Analyze only intra-residue interactions
+   - ``inter``: Analyze interactions between different residues only (default)
+   - ``all``: Analyze both inter-residue and intra-residue interactions
 
 Structure Fixing Options
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -414,11 +414,11 @@ Use a preset with custom overrides:
 
    hbat protein.pdb --preset drug_design_strict --hb-distance 3.0
 
-Analyze only local interactions:
+Analyze inter-residue interactions only:
 
 .. code-block:: bash
 
-   hbat protein.pdb --mode local
+   hbat protein.pdb --mode inter
 
 Quick summary with quiet output:
 

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -185,6 +185,32 @@ General Parameters
    - ``inter``: Analyze interactions between different residues only (default)
    - ``all``: Analyze both inter-residue and intra-residue interactions
 
+Interaction Inclusion Modes
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The interaction inclusion mode controls whether interactions within the same
+residue are reported:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 25 25
+
+   * - Mode
+     - Inter-residue
+     - Intra-residue
+   * - ``inter``
+     - Yes
+     - No
+   * - ``all``
+     - Yes
+     - Yes
+
+.. important::
+
+   This is a breaking change. The previous ``local`` and ``complete`` values
+   are no longer valid. Replace ``local`` with ``inter`` and ``complete`` with
+   ``all`` in scripts, API calls, and preset files.
+
 Structure Fixing Options
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/logic.rst
+++ b/docs/source/logic.rst
@@ -285,7 +285,8 @@ Calculation Process
 4. **Validation**:
 
    - Check centroid-to-centroid distance
-   - Verify interaction is between different residues
+   - Apply the interaction inclusion mode: ``inter`` excludes same-residue
+     interactions, while ``all`` includes them
    - Apply distance and angle cutoffs
 
 Carbonyl Interactions (n→π*)

--- a/docs/source/presets.rst
+++ b/docs/source/presets.rst
@@ -312,6 +312,13 @@ Invalid preset format:
 - Ensure JSON syntax is correct
 - Verify all required fields are present
 - Check parameter value ranges
+- Replace legacy ``analysis_mode`` values before loading:
+
+  - ``local`` must be changed to ``inter``
+  - ``complete`` must be changed to ``all``
+
+  Legacy preset values are intentionally rejected rather than migrated
+  automatically.
 
 Permission errors:
 

--- a/docs/source/presets.rst
+++ b/docs/source/presets.rst
@@ -198,7 +198,7 @@ HBAT presets are saved as JSON files with the following structure:
        },
        "general": {
          "covalent_cutoff_factor": 0.85,
-         "analysis_mode": "complete"
+         "analysis_mode": "all"
        },
        "pdb_fixing": {
          "enabled": true,

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -17,7 +17,7 @@ See full CLI options :doc:`cli`.
    hbat input.pdb -o results.txt           # Save results to text file
    hbat input.pdb --csv results            # Export to multiple CSV files
    hbat input.pdb --hb-distance 3.0        # Custom H-bond distance cutoff
-   hbat input.pdb --mode local             # Local interactions only
+   hbat input.pdb --mode inter             # Inter-residue interactions only
    hbat input.pdb -o results.json          # Export to single JSON file
    hbat --list-presets                     # List available presets
    hbat input.pdb --preset high_resolution # Use preset

--- a/docs/source/web.rst
+++ b/docs/source/web.rst
@@ -50,7 +50,10 @@ After uploading a PDB file:
 
 - **Fix PDB**: Enable PDB fixing (adds missing atoms/hydrogens)
 - **Fixing Method**: Choose between OpenBabel or PDBFixer
-- **Analysis Mode**: Complete (all interactions) or Local (intra-residue only)
+- **Interaction Inclusion**:
+
+  - ``inter``: Include interactions between different residues only (default)
+  - ``all``: Include both inter-residue and intra-residue interactions
 
 **Hydrogen Bond Parameters**:
 

--- a/example_presets/drug_design_strict.hbat
+++ b/example_presets/drug_design_strict.hbat
@@ -56,7 +56,7 @@
     },
     "general": {
       "covalent_cutoff_factor": 0.85,
-      "analysis_mode": "complete"
+      "analysis_mode": "all"
     },
     "pdb_fixing": {
       "enabled": true,

--- a/example_presets/high_resolution.hbat
+++ b/example_presets/high_resolution.hbat
@@ -56,7 +56,7 @@
     },
     "general": {
       "covalent_cutoff_factor": 0.85,
-      "analysis_mode": "complete"
+      "analysis_mode": "all"
     },
     "pdb_fixing": {
       "enabled": false,

--- a/example_presets/low_resolution.hbat
+++ b/example_presets/low_resolution.hbat
@@ -56,7 +56,7 @@
     },
     "general": {
       "covalent_cutoff_factor": 0.85,
-      "analysis_mode": "complete"
+      "analysis_mode": "all"
     },
     "pdb_fixing": {
       "enabled": true,

--- a/example_presets/membrane_proteins.hbat
+++ b/example_presets/membrane_proteins.hbat
@@ -56,7 +56,7 @@
     },
     "general": {
       "covalent_cutoff_factor": 0.85,
-      "analysis_mode": "complete"
+      "analysis_mode": "all"
     },
     "pdb_fixing": {
       "enabled": true,

--- a/example_presets/nmr_structures.hbat
+++ b/example_presets/nmr_structures.hbat
@@ -56,7 +56,7 @@
     },
     "general": {
       "covalent_cutoff_factor": 0.85,
-      "analysis_mode": "complete"
+      "analysis_mode": "all"
     },
     "pdb_fixing": {
       "enabled": true,

--- a/example_presets/standard_resolution.hbat
+++ b/example_presets/standard_resolution.hbat
@@ -56,7 +56,7 @@
     },
     "general": {
       "covalent_cutoff_factor": 0.85,
-      "analysis_mode": "complete"
+      "analysis_mode": "all"
     },
     "pdb_fixing": {
       "enabled": false,

--- a/example_presets/strong_interactions_only.hbat
+++ b/example_presets/strong_interactions_only.hbat
@@ -56,7 +56,7 @@
     },
     "general": {
       "covalent_cutoff_factor": 0.85,
-      "analysis_mode": "complete"
+      "analysis_mode": "all"
     },
     "pdb_fixing": {
       "enabled": false,

--- a/example_presets/weak_interactions_permissive.hbat
+++ b/example_presets/weak_interactions_permissive.hbat
@@ -56,7 +56,7 @@
     },
     "general": {
       "covalent_cutoff_factor": 0.85,
-      "analysis_mode": "complete"
+      "analysis_mode": "all"
     },
     "pdb_fixing": {
       "enabled": true,

--- a/hbat/cli/main.py
+++ b/hbat/cli/main.py
@@ -85,7 +85,7 @@ Examples:
   %(prog)s input.pdb --csv results           # Export to multiple CSV files (one per interaction type)
   %(prog)s input.pdb --json results          # Export to multiple JSON files (one per interaction type)
   %(prog)s input.pdb --hb-distance 3.0       # Custom H-bond distance cutoff
-  %(prog)s input.pdb --mode local            # Local interactions only
+  %(prog)s input.pdb --mode inter            # Inter-residue interactions only
   %(prog)s --list-presets                    # List available presets
   %(prog)s input.pdb --preset high_resolution # Use preset with custom overrides
         """,
@@ -357,12 +357,15 @@ Examples:
         help=f"Covalent bond detection factor (default: {ParametersDefault.COVALENT_CUTOFF_FACTOR})",
     )
 
-    # Analysis mode
+    # Interaction inclusion mode
     param_group.add_argument(
         "--mode",
-        choices=["complete", "local"],
+        choices=["inter", "all"],
         default=ParametersDefault.ANALYSIS_MODE,
-        help="Analysis mode: complete (all interactions) or local (intra-residue only)",
+        help=(
+            "Interaction inclusion mode: inter includes interactions between "
+            "different residues only; all also includes intra-residue interactions"
+        ),
     )
 
     # PDB structure fixing options
@@ -1215,7 +1218,9 @@ def run_analysis(args: argparse.Namespace) -> int:
         parameters = load_parameters_from_args(args)
 
         print_progress(f"Starting analysis of {args.input}", verbose)
-        print_progress(f"Analysis mode: {parameters.analysis_mode}", verbose)
+        print_progress(
+            f"Interaction inclusion mode: {parameters.analysis_mode}", verbose
+        )
 
         # Create analyzer
         analyzer = NPMolecularInteractionAnalyzer(parameters)

--- a/hbat/cli/main.py
+++ b/hbat/cli/main.py
@@ -558,7 +558,7 @@ def load_preset_file(preset_path: str) -> AnalysisParameters:
         general_params = params.get("general", {})
         fix_params = params.get("pdb_fixing", {})
 
-        return AnalysisParameters(
+        preset_params = AnalysisParameters(
             hb_distance_cutoff=hb_params.get(
                 "h_a_distance_cutoff", ParametersDefault.HB_DISTANCE_CUTOFF
             ),
@@ -698,6 +698,8 @@ def load_preset_file(preset_path: str) -> AnalysisParameters:
                 "angle_max", ParametersDefault.N_PI_ANGLE_MAX
             ),
         )
+        preset_params.validate_or_raise("preset parameters")
+        return preset_params
 
     except Exception as e:
         print_error(f"Failed to load preset file '{preset_path}': {str(e)}")

--- a/hbat/config/ui_config.py
+++ b/hbat/config/ui_config.py
@@ -955,10 +955,13 @@ PARAMETER_CONFIGS: List[ParameterConfig] = [
     ),
     ParameterConfig(
         name="analysis_mode",
-        label="Analysis Mode",
-        default="local",
+        label="Interaction Inclusion",
+        default="inter",
         category="General",
-        description="Analysis mode: 'local' or 'complete'",
+        description=(
+            "Interaction inclusion mode: 'inter' for different residues only "
+            "or 'all' to include same-residue interactions"
+        ),
         param_type="str",
     ),
     # PDB Structure Fixing Parameters

--- a/hbat/constants/parameters.py
+++ b/hbat/constants/parameters.py
@@ -964,6 +964,17 @@ class AnalysisParameters:
 
         return errors
 
+    def validate_or_raise(self, context: str = "parameters") -> None:
+        """Validate parameters and raise a descriptive error when invalid.
+
+        :param context: Description of where the parameters came from
+        :type context: str
+        :raises ValueError: If one or more parameters are invalid
+        """
+        errors = self.validate()
+        if errors:
+            raise ValueError(f"Invalid {context}: {'; '.join(errors)}")
+
 
 # Parameter validation ranges
 class ParameterRanges:

--- a/hbat/constants/parameters.py
+++ b/hbat/constants/parameters.py
@@ -81,7 +81,7 @@ class ParametersDefault:
 
     # General analysis parameters
     COVALENT_CUTOFF_FACTOR = 0.85  # Covalent bond detection factor (0.0-1.0)
-    ANALYSIS_MODE = "local"  # Analysis mode: "complete" or "local"
+    ANALYSIS_MODE = "inter"  # Interaction inclusion mode: "inter" or "all"
 
     # Bond distance thresholds
     MAX_BOND_DISTANCE = 2.5  # Reasonable maximum for most covalent bonds (Angstroms)
@@ -222,7 +222,7 @@ class AnalysisParameters:
     :type n_pi_angle_max: float
     :param covalent_cutoff_factor: Factor for covalent bond detection
     :type covalent_cutoff_factor: float
-    :param analysis_mode: Analysis mode ('local' or 'global')
+    :param analysis_mode: Interaction inclusion mode ('inter' or 'all')
     :type analysis_mode: str
     :param fix_pdb_enabled: Enable PDB structure fixing
     :type fix_pdb_enabled: bool
@@ -323,7 +323,7 @@ class AnalysisParameters:
         :type pi_angle_cutoff: float
         :param covalent_cutoff_factor: Factor for covalent bond detection
         :type covalent_cutoff_factor: float
-        :param analysis_mode: Analysis mode ('local' or 'global')
+        :param analysis_mode: Interaction inclusion mode ('inter' or 'all')
         :type analysis_mode: str
         :param fix_pdb_enabled: Enable PDB structure fixing
         :type fix_pdb_enabled: bool
@@ -1009,12 +1009,12 @@ class PDBFixingModes:
 
 # Analysis mode constants
 class AnalysisModes:
-    """Available analysis modes."""
+    """Available interaction inclusion modes."""
 
-    COMPLETE = "complete"
-    LOCAL = "local"
+    INTER = "inter"
+    ALL = "all"
 
-    ALL_MODES = [COMPLETE, LOCAL]
+    ALL_MODES = [INTER, ALL]
 
 
 # Bond detection method constants

--- a/hbat/core/np_analyzer.py
+++ b/hbat/core/np_analyzer.py
@@ -23,7 +23,7 @@ from ..constants import (
     RING_ATOMS_FOR_RESIDUES_WITH_AROMATIC_RINGS,
     WATER_MOLECULES,
 )
-from ..constants.parameters import AnalysisParameters
+from ..constants.parameters import AnalysisModes, AnalysisParameters
 from .interactions import (
     CarbonylInteraction,
     CooperativityChain,
@@ -451,8 +451,8 @@ class NPMolecularInteractionAnalyzer:
                 if donor_atom.serial == a_atom.serial:
                     continue
 
-                # Skip if same residue (for local mode) - optimized check
-                if self.parameters.analysis_mode == "local":
+                # Inter mode excludes interactions within the same residue
+                if self.parameters.analysis_mode == AnalysisModes.INTER:
                     acceptor_idx = self._atom_indices["acceptor"][a_idx]
                     if self._are_same_residue(donor_idx, acceptor_idx):
                         continue
@@ -574,7 +574,7 @@ class NPMolecularInteractionAnalyzer:
         4. For each candidate pair, find carbon atom bonded to halogen
         5. Calculate C-X···A angle
         6. Verify angle ≥ 150° for linear σ-hole geometry
-        7. Skip same-residue interactions (local mode only)
+        7. Skip same-residue interactions (inter mode only)
         8. Create HalogenBond objects for valid interactions
         """
         if (
@@ -622,8 +622,8 @@ class NPMolecularInteractionAnalyzer:
                     self._atom_indices["halogen_acceptor"][a_idx]
                 ]
 
-                # Skip if same residue (for local mode) - optimized check
-                if self.parameters.analysis_mode == "local":
+                # Inter mode excludes interactions within the same residue
+                if self.parameters.analysis_mode == AnalysisModes.INTER:
                     halogen_idx = self._atom_indices["halogen"][x_idx]
                     acceptor_idx = self._atom_indices["halogen_acceptor"][a_idx]
                     if self._are_same_residue(halogen_idx, acceptor_idx):
@@ -714,7 +714,7 @@ class NPMolecularInteractionAnalyzer:
         5. Filter pairs within subtype-specific distance cutoff
         6. Calculate D-H···π or D-X···π angle for each candidate
         7. Verify angle meets minimum threshold for interaction subtype
-        8. Skip same-residue interactions (local mode only)
+        8. Skip same-residue interactions (inter mode only)
         9. Create PiInteraction objects for valid interactions
         """
         # Get all aromatic rings with residue filter
@@ -771,8 +771,8 @@ class NPMolecularInteractionAnalyzer:
             for center_idx in close_centers:
                 center_info = aromatic_centers[center_idx]
 
-                # Skip same residue (for local mode) - optimized check
-                if self.parameters.analysis_mode == "local":
+                # Inter mode excludes interactions within the same residue
+                if self.parameters.analysis_mode == AnalysisModes.INTER:
                     donor_idx = self._serial_to_idx.get(donor_atom.serial)
                     if donor_idx is not None:
                         # Create residue key for aromatic center

--- a/hbat/core/np_analyzer.py
+++ b/hbat/core/np_analyzer.py
@@ -69,9 +69,7 @@ class NPMolecularInteractionAnalyzer:
         self.parameters = parameters or AnalysisParameters()
 
         # Validate parameters
-        validation_errors = self.parameters.validate()
-        if validation_errors:
-            raise ValueError(f"Invalid parameters: {'; '.join(validation_errors)}")
+        self.parameters.validate_or_raise()
 
         self.parser = PDBParser()
         self.hydrogen_bonds: List[HydrogenBond] = []
@@ -347,6 +345,20 @@ class NPMolecularInteractionAnalyzer:
             atom2_idx
         )
 
+    def _should_skip_same_residue(self, residue1: Any, residue2: Any) -> bool:
+        """Return whether an interaction between two residues should be skipped."""
+        return (
+            self.parameters.analysis_mode == AnalysisModes.INTER
+            and residue1 == residue2
+        )
+
+    def _should_skip_atom_pair(self, atom1_idx: int, atom2_idx: int) -> bool:
+        """Return whether an atom pair should be skipped based on residue mode."""
+        return self._should_skip_same_residue(
+            self._atom_to_residue.get(atom1_idx),
+            self._atom_to_residue.get(atom2_idx),
+        )
+
     def _find_hydrogen_bonds_vectorized(self) -> None:
         """Find hydrogen bonds using vectorized NumPy operations.
 
@@ -452,10 +464,9 @@ class NPMolecularInteractionAnalyzer:
                     continue
 
                 # Inter mode excludes interactions within the same residue
-                if self.parameters.analysis_mode == AnalysisModes.INTER:
-                    acceptor_idx = self._atom_indices["acceptor"][a_idx]
-                    if self._are_same_residue(donor_idx, acceptor_idx):
-                        continue
+                acceptor_idx = self._atom_indices["acceptor"][a_idx]
+                if self._should_skip_atom_pair(donor_idx, acceptor_idx):
+                    continue
 
                 # Calculate angle using NPVec3D
                 donor_vec = NPVec3D(
@@ -623,11 +634,10 @@ class NPMolecularInteractionAnalyzer:
                 ]
 
                 # Inter mode excludes interactions within the same residue
-                if self.parameters.analysis_mode == AnalysisModes.INTER:
-                    halogen_idx = self._atom_indices["halogen"][x_idx]
-                    acceptor_idx = self._atom_indices["halogen_acceptor"][a_idx]
-                    if self._are_same_residue(halogen_idx, acceptor_idx):
-                        continue
+                halogen_idx = self._atom_indices["halogen"][x_idx]
+                acceptor_idx = self._atom_indices["halogen_acceptor"][a_idx]
+                if self._should_skip_atom_pair(halogen_idx, acceptor_idx):
+                    continue
 
                 # Check distance criteria: vdW sum OR fixed cutoff
                 distance = float(distances[x_idx, a_idx])
@@ -772,18 +782,18 @@ class NPMolecularInteractionAnalyzer:
                 center_info = aromatic_centers[center_idx]
 
                 # Inter mode excludes interactions within the same residue
-                if self.parameters.analysis_mode == AnalysisModes.INTER:
-                    donor_idx = self._serial_to_idx.get(donor_atom.serial)
-                    if donor_idx is not None:
-                        # Create residue key for aromatic center
-                        aromatic_residue_key = (
-                            center_info["residue"].chain_id,
-                            center_info["residue"].seq_num,
-                            center_info["residue"].name,
-                        )
-                        donor_residue_key = self._atom_to_residue.get(donor_idx)
-                        if donor_residue_key == aromatic_residue_key:
-                            continue
+                donor_idx = self._serial_to_idx.get(donor_atom.serial)
+                if donor_idx is not None:
+                    aromatic_residue_key = (
+                        center_info["residue"].chain_id,
+                        center_info["residue"].seq_num,
+                        center_info["residue"].name,
+                    )
+                    donor_residue_key = self._atom_to_residue.get(donor_idx)
+                    if self._should_skip_same_residue(
+                        donor_residue_key, aromatic_residue_key
+                    ):
+                        continue
 
                 # Calculate angle
                 donor_vec = NPVec3D(
@@ -1011,7 +1021,8 @@ class NPMolecularInteractionAnalyzer:
         6. Compute angle between plane normals (0° = parallel, 90° = perpendicular)
         7. Calculate lateral offset for parallel configurations
         8. Classify stacking type based on angle and offset criteria
-        9. Create PiPiInteraction objects with stacking type annotation
+        9. Exclude same-residue interactions in inter mode
+        10. Create PiPiInteraction objects with stacking type annotation
         """
         if self.parameters.pi_pi_distance_cutoff <= 0:
             return  # Skip if disabled
@@ -1045,8 +1056,10 @@ class NPMolecularInteractionAnalyzer:
         # Pairwise comparison of all aromatic rings
         for i, ring1 in enumerate(aromatic_rings):
             for ring2 in aromatic_rings[i + 1 :]:
-                # Skip same residue
-                if ring1["residue"] == ring2["residue"]:
+                # Inter mode excludes interactions within the same residue
+                if self._should_skip_same_residue(
+                    ring1["residue"], ring2["residue"]
+                ):
                     continue
 
                 # Calculate centroid-to-centroid distance
@@ -1158,7 +1171,7 @@ class NPMolecularInteractionAnalyzer:
         **Algorithm:**
 
         1. Identify all C=O groups from backbone and sidechains
-        2. For each carbonyl pair from different residues:
+        2. For each carbonyl pair allowed by the interaction inclusion mode:
            a. Calculate O···C distance between donor oxygen and acceptor carbon
            b. Filter pairs within 3.2 Å distance cutoff
            c. Calculate Bürgi-Dunitz angle (O···C=O)
@@ -1194,8 +1207,10 @@ class NPMolecularInteractionAnalyzer:
         # Pairwise comparison of carbonyl groups
         for i, donor_carbonyl in enumerate(carbonyl_data):
             for acceptor_carbonyl in carbonyl_data[i + 1 :]:
-                # Skip same residue interactions
-                if donor_carbonyl["residue_id"] == acceptor_carbonyl["residue_id"]:
+                # Inter mode excludes interactions within the same residue
+                if self._should_skip_same_residue(
+                    donor_carbonyl["residue_id"], acceptor_carbonyl["residue_id"]
+                ):
                     continue
 
                 # Get atom coordinates
@@ -1406,7 +1421,7 @@ class NPMolecularInteractionAnalyzer:
            d. Calculate angle_to_normal (donor→π vector vs. plane normal)
            e. Convert to angle_to_plane (90° - angle_to_normal)
            f. Verify angle_to_plane is 0-45° (shallow approach)
-        4. Skip same-residue interactions
+        4. Exclude same-residue interactions in inter mode
         5. Create NPiInteraction objects with subtype classification
         """
         if self.parameters.n_pi_distance_cutoff <= 0:
@@ -1457,7 +1472,7 @@ class NPMolecularInteractionAnalyzer:
                 ring_center = ring_info["center"]
                 ring_atoms = ring_info["atoms"]
 
-                # Skip same residue interactions
+                # Inter mode excludes interactions within the same residue
                 donor_residue_key = (
                     donor_atom.chain_id,
                     donor_atom.res_seq,
@@ -1468,7 +1483,9 @@ class NPMolecularInteractionAnalyzer:
                     ring_info["residue"].seq_num,
                     ring_info["residue"].name,
                 )
-                if donor_residue_key == acceptor_residue_key:
+                if self._should_skip_same_residue(
+                    donor_residue_key, acceptor_residue_key
+                ):
                     continue
 
                 # Calculate distance to π center

--- a/hbat/gui/geometry_cutoffs_dialog.py
+++ b/hbat/gui/geometry_cutoffs_dialog.py
@@ -1376,8 +1376,11 @@ class GeometryCutoffsDialog:
 
         if result:
             # Apply the loaded preset
-            self._apply_preset_data(result)
-            messagebox.showinfo("Success", "Preset loaded successfully")
+            try:
+                self._apply_preset_data(result)
+                messagebox.showinfo("Success", "Preset loaded successfully")
+            except ValueError as e:
+                messagebox.showerror("Invalid Preset", str(e))
 
     def _apply_preset_data(self, data: Dict[str, Any]) -> None:
         """Apply preset data to parameters."""
@@ -1385,6 +1388,7 @@ class GeometryCutoffsDialog:
             raise ValueError("Invalid preset format: missing 'parameters' section")
 
         params = data["parameters"]
+        previous_params = self.get_parameters()
 
         # Helper to apply value to parameter
         def apply_value(field_name, value):
@@ -1521,6 +1525,12 @@ class GeometryCutoffsDialog:
                 "analysis_mode",
                 gen.get("analysis_mode", ParametersDefault.ANALYSIS_MODE),
             )
+
+        try:
+            self.get_parameters().validate_or_raise("preset parameters")
+        except ValueError:
+            self.set_parameters(previous_params)
+            raise
 
     def _ok(self):
         """Handle OK button - save settings and close."""

--- a/hbat/gui/geometry_cutoffs_dialog.py
+++ b/hbat/gui/geometry_cutoffs_dialog.py
@@ -274,8 +274,8 @@ class GeometryCutoffsDialog:
         group = ttk.LabelFrame(parent, text="General Parameters", padding=10)
         group.pack(fill=tk.X, padx=10, pady=5)
 
-        # Analysis mode
-        ttk.Label(group, text="Analysis Mode:").grid(
+        # Interaction inclusion mode
+        ttk.Label(group, text="Interaction Inclusion:").grid(
             row=0, column=0, sticky=tk.W, pady=2
         )
         stored_mode = self._param_values.get(
@@ -287,15 +287,15 @@ class GeometryCutoffsDialog:
 
         ttk.Radiobutton(
             mode_frame,
-            text="Complete PDB Analysis",
+            text="All interactions",
             variable=self._vars["analysis_mode"],
-            value="complete",
+            value="all",
         ).pack(anchor=tk.W)
         ttk.Radiobutton(
             mode_frame,
-            text="Local Interactions Only",
+            text="Inter-residue only",
             variable=self._vars["analysis_mode"],
-            value="local",
+            value="inter",
         ).pack(anchor=tk.W)
 
         # Covalent bond cutoff factor

--- a/hbat/gui/main_window.py
+++ b/hbat/gui/main_window.py
@@ -1200,22 +1200,22 @@ Author: Abhishek Tiwari
 
         if result:
             # Apply the loaded preset to session parameters
-            self._apply_preset_to_session(result)
-            self.status_var.set("Preset loaded and applied to session")
+            if self._apply_preset_to_session(result):
+                self.status_var.set("Preset loaded and applied to session")
 
-    def _apply_preset_to_session(self, preset_data: Dict[str, Any]) -> None:
+    def _apply_preset_to_session(self, preset_data: Dict[str, Any]) -> bool:
         """Apply preset data to session parameters.
 
         :param preset_data: Preset data to apply
         :type preset_data: Dict[str, Any]
-        :returns: None
-        :rtype: None
+        :returns: True if the preset was valid and applied, otherwise False
+        :rtype: bool
         """
         if "parameters" not in preset_data:
             messagebox.showerror(
                 "Error", "Invalid preset format: missing 'parameters' section"
             )
-            return
+            return False
 
         params_data = preset_data["parameters"]
 
@@ -1282,8 +1282,16 @@ Author: Abhishek Tiwari
                 }
             )
 
-        # Create new parameters object and store in session
-        self.session_parameters = AnalysisParameters(**kwargs)
+        # Validate before replacing the active session parameters
+        preset_params = AnalysisParameters(**kwargs)
+        try:
+            preset_params.validate_or_raise("preset parameters")
+        except ValueError as e:
+            messagebox.showerror("Invalid Preset", str(e))
+            return False
+
+        self.session_parameters = preset_params
+        return True
 
     def _on_closing(self) -> None:
         """Handle window closing event.

--- a/hbat/gui/preset_manager_dialog.py
+++ b/hbat/gui/preset_manager_dialog.py
@@ -542,7 +542,7 @@ n→π* Interaction Parameters:
 
 General Parameters:
   Covalent Bond Factor: {params.covalent_cutoff_factor:.2f}
-  Analysis Mode: {params.analysis_mode}
+  Interaction Inclusion: {params.analysis_mode}
 """
 
         # Add PDB fixing parameters if they exist

--- a/hbat/server/components/parameter_panel.py
+++ b/hbat/server/components/parameter_panel.py
@@ -668,13 +668,16 @@ class ParameterPanel:
 
             with ui.column().classes("w-full q-mt-md gap-4"):
                 ui.select(
-                    options=["complete", "local"],
-                    label="Analysis Mode",
+                    options={
+                        "inter": "Inter-residue only",
+                        "all": "All interactions",
+                    },
+                    label="Interaction Inclusion",
                     value=self.analysis_mode,
                     with_input=True,
                 ).bind_value(self, "analysis_mode").tooltip(
-                    "complete: Include all interactions (including intra-residue); "
-                    "local: Exclude intra-residue interactions"
+                    "inter: Exclude interactions within the same residue; "
+                    "all: Include inter-residue and intra-residue interactions"
                 )
 
                 ui.number(

--- a/tests/cli/test_cli_main.py
+++ b/tests/cli/test_cli_main.py
@@ -108,7 +108,7 @@ class TestPresetManagement:
                 },
                 "general": {
                     "covalent_cutoff_factor": 0.85,
-                    "analysis_mode": "complete",
+                    "analysis_mode": "all",
                 },
                 "pdb_fixing": {
                     "enabled": True,
@@ -131,7 +131,7 @@ class TestPresetManagement:
             assert isinstance(params, AnalysisParameters)
             assert params.hb_distance_cutoff == 3.5
             assert params.hb_angle_cutoff == 120.0
-            assert params.analysis_mode == "complete"
+            assert params.analysis_mode == "all"
             # Test PDB fixing parameters are loaded
             assert params.fix_pdb_enabled is True
             assert params.fix_pdb_method == "pdbfixer"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -130,7 +130,7 @@ def analysis_parameters():
         hb_distance_cutoff=3.5,
         hb_angle_cutoff=120.0,
         hb_donor_acceptor_cutoff=4.0,
-        analysis_mode="complete",
+        analysis_mode="all",
     )
 
 
@@ -175,7 +175,7 @@ def strict_analysis_parameters():
         hb_distance_cutoff=3.0,
         hb_angle_cutoff=130.0,
         hb_donor_acceptor_cutoff=3.7,
-        analysis_mode="complete",
+        analysis_mode="all",
     )
 
 
@@ -245,7 +245,7 @@ def performance_parameters():
     return AnalysisParameters(
         hb_distance_cutoff=4.0,
         hb_angle_cutoff=110.0,
-        analysis_mode="complete",
+        analysis_mode="all",
         fix_pdb_enabled=False,
     )
 

--- a/tests/e2e/test_complete_analysis_workflows.py
+++ b/tests/e2e/test_complete_analysis_workflows.py
@@ -116,19 +116,19 @@ def pdb_structure(request):
             "name": "strict",
             "hb_distance_cutoff": 3.0,
             "hb_angle_cutoff": 140.0,
-            "analysis_mode": "local",
+            "analysis_mode": "inter",
         },
         {
             "name": "permissive",
             "hb_distance_cutoff": 4.0,
             "hb_angle_cutoff": 110.0,
-            "analysis_mode": "complete",
+            "analysis_mode": "all",
         },
         {
             "name": "default",
             "hb_distance_cutoff": None,  # Use defaults
             "hb_angle_cutoff": None,
-            "analysis_mode": "complete",
+            "analysis_mode": "all",
         },
     ]
 )

--- a/tests/e2e/test_gui_workflows.py
+++ b/tests/e2e/test_gui_workflows.py
@@ -251,7 +251,7 @@ class TestAnalysisWorkflows(BaseGUIWorkflowTest):
 
         # Test that parameters can be created and used for analysis
         gui_params = AnalysisParameters(
-            hb_distance_cutoff=3.2, hb_angle_cutoff=125.0, analysis_mode="complete"
+            hb_distance_cutoff=3.2, hb_angle_cutoff=125.0, analysis_mode="all"
         )
 
         # Test analysis with GUI parameters
@@ -322,7 +322,7 @@ class TestPresetWorkflows(BaseGUIWorkflowTest):
 
         # Simulate preset save/load workflow
         original_params = AnalysisParameters(
-            hb_distance_cutoff=3.1, hb_angle_cutoff=135.0, analysis_mode="local"
+            hb_distance_cutoff=3.1, hb_angle_cutoff=135.0, analysis_mode="inter"
         )
 
         # Create temporary preset file

--- a/tests/gui/test_gui_components.py
+++ b/tests/gui/test_gui_components.py
@@ -151,7 +151,7 @@ class TestGeometryCutoffsDialog:
                 hb_distance_cutoff=3.2,
                 hb_angle_cutoff=125.0,
                 whb_distance_cutoff=3.8,
-                analysis_mode="local",
+                analysis_mode="inter",
             )
             dialog.set_parameters(test_params)
 
@@ -161,7 +161,7 @@ class TestGeometryCutoffsDialog:
             assert result_params.hb_distance_cutoff == 3.2
             assert result_params.hb_angle_cutoff == 125.0
             assert result_params.whb_distance_cutoff == 3.8
-            assert result_params.analysis_mode == "local"
+            assert result_params.analysis_mode == "inter"
 
         finally:
             dialog.dialog.destroy()
@@ -179,7 +179,7 @@ class TestGeometryCutoffsDialog:
                 hb_distance_cutoff=3.1,
                 hb_angle_cutoff=130.0,
                 whb_distance_cutoff=3.7,
-                analysis_mode="complete",
+                analysis_mode="all",
             )
 
             dialog.set_parameters(new_params)
@@ -188,7 +188,7 @@ class TestGeometryCutoffsDialog:
             assert dialog._param_values["hb_distance_cutoff"] == 3.1
             assert dialog._param_values["hb_angle_cutoff"] == 130.0
             assert dialog._param_values["whb_distance_cutoff"] == 3.7
-            assert dialog._param_values["analysis_mode"] == "complete"
+            assert dialog._param_values["analysis_mode"] == "all"
 
         finally:
             dialog.dialog.destroy()
@@ -337,7 +337,7 @@ class TestGeometryCutoffsDialogAdvanced:
             hb_angle_cutoff=115.0,
             whb_distance_cutoff=3.7,
             xb_distance_cutoff=4.1,
-            analysis_mode="local",
+            analysis_mode="inter",
         )
 
         dialog = GeometryCutoffsDialog(self.root, initial_params)
@@ -346,7 +346,7 @@ class TestGeometryCutoffsDialogAdvanced:
             # Step 2: Verify initial parameters are set
             result1 = dialog.get_parameters()
             assert result1.hb_distance_cutoff == 3.1
-            assert result1.analysis_mode == "local"
+            assert result1.analysis_mode == "inter"
 
             # Step 3: Simulate parameter modifications by setting new parameters
             modified_params = AnalysisParameters(
@@ -354,7 +354,7 @@ class TestGeometryCutoffsDialogAdvanced:
                 hb_angle_cutoff=115.0,  # Original
                 whb_distance_cutoff=3.8,  # Modified
                 xb_distance_cutoff=4.2,  # Modified
-                analysis_mode="local",  # Original
+                analysis_mode="inter",  # Original
             )
             dialog.set_parameters(modified_params)
 
@@ -372,7 +372,7 @@ class TestGeometryCutoffsDialogAdvanced:
             assert final_params.hb_angle_cutoff == 115.0  # Original
             assert final_params.whb_distance_cutoff == 3.8  # Modified
             assert final_params.xb_distance_cutoff == 4.2  # Modified
-            assert final_params.analysis_mode == "local"  # Original
+            assert final_params.analysis_mode == "inter"  # Original
 
         finally:
             dialog.dialog.destroy()
@@ -399,7 +399,7 @@ class TestGeometryCutoffsDialogAdvanced:
                     },
                     "general": {
                         "covalent_cutoff_factor": 0.9,
-                        "analysis_mode": "complete",
+                        "analysis_mode": "all",
                     },
                 }
             }
@@ -412,7 +412,7 @@ class TestGeometryCutoffsDialogAdvanced:
             assert result_params.hb_distance_cutoff == 3.3
             assert result_params.hb_angle_cutoff == 125.0
             assert result_params.xb_distance_cutoff == 4.2
-            assert result_params.analysis_mode == "complete"
+            assert result_params.analysis_mode == "all"
 
         finally:
             dialog.dialog.destroy()
@@ -519,7 +519,7 @@ class TestGeometryCutoffsDialogAdvanced:
         try:
             # Set parameters properly first
             test_params = AnalysisParameters(
-                hb_distance_cutoff=3.4, hb_angle_cutoff=128.0, analysis_mode="local"
+                hb_distance_cutoff=3.4, hb_angle_cutoff=128.0, analysis_mode="inter"
             )
             dialog.set_parameters(test_params)
 
@@ -537,7 +537,7 @@ class TestGeometryCutoffsDialogAdvanced:
             result = dialog.get_parameters()
             assert result.hb_distance_cutoff == 3.4
             assert result.hb_angle_cutoff == 128.0
-            assert result.analysis_mode == "local"
+            assert result.analysis_mode == "inter"
 
         finally:
             dialog.dialog.destroy()

--- a/tests/integration/test_analyzer_core.py
+++ b/tests/integration/test_analyzer_core.py
@@ -45,7 +45,7 @@ class TestAnalyzerParserIntegration:
         """Test analyzer parameters affect parsing behavior."""
         # Create analyzer with custom parameters
         params = AnalysisParameters(
-            covalent_cutoff_factor=0.9, analysis_mode="complete"
+            covalent_cutoff_factor=0.9, analysis_mode="all"
         )
         analyzer = MolecularInteractionAnalyzer(params)
 
@@ -54,7 +54,7 @@ class TestAnalyzerParserIntegration:
 
         # Verify parameters are applied
         assert analyzer.parameters.covalent_cutoff_factor == 0.9
-        assert analyzer.parameters.analysis_mode == "complete"
+        assert analyzer.parameters.analysis_mode == "all"
 
         # Verify parser reflects parameter settings
         atoms = analyzer.parser.atoms
@@ -230,41 +230,41 @@ class TestAnalyzerParameterIntegration:
 
     def test_analysis_mode_effects(self, sample_pdb_file):
         """Test analysis mode effects."""
-        # Complete mode
-        complete_params = AnalysisParameters(analysis_mode="complete")
-        complete_analyzer = MolecularInteractionAnalyzer(complete_params)
+        # All mode includes both inter-residue and intra-residue interactions
+        all_params = AnalysisParameters(analysis_mode="all")
+        all_analyzer = MolecularInteractionAnalyzer(all_params)
 
-        # Local mode
-        local_params = AnalysisParameters(analysis_mode="local")
-        local_analyzer = MolecularInteractionAnalyzer(local_params)
+        # Inter mode excludes intra-residue interactions
+        inter_params = AnalysisParameters(analysis_mode="inter")
+        inter_analyzer = MolecularInteractionAnalyzer(inter_params)
 
         # Analyze with both modes
-        complete_success = complete_analyzer.analyze_file(sample_pdb_file)
-        local_success = local_analyzer.analyze_file(sample_pdb_file)
+        all_success = all_analyzer.analyze_file(sample_pdb_file)
+        inter_success = inter_analyzer.analyze_file(sample_pdb_file)
 
-        assert complete_success and local_success
+        assert all_success and inter_success
 
         # Compare results
-        # Create statistics from complete analyzer results
-        complete_stats = {
-            "hydrogen_bonds": len(complete_analyzer.hydrogen_bonds),
-            "halogen_bonds": len(complete_analyzer.halogen_bonds),
-            "pi_interactions": len(complete_analyzer.pi_interactions),
-            "total_interactions": len(complete_analyzer.hydrogen_bonds)
-            + len(complete_analyzer.halogen_bonds)
-            + len(complete_analyzer.pi_interactions),
+        # Create statistics from all-mode analyzer results
+        all_stats = {
+            "hydrogen_bonds": len(all_analyzer.hydrogen_bonds),
+            "halogen_bonds": len(all_analyzer.halogen_bonds),
+            "pi_interactions": len(all_analyzer.pi_interactions),
+            "total_interactions": len(all_analyzer.hydrogen_bonds)
+            + len(all_analyzer.halogen_bonds)
+            + len(all_analyzer.pi_interactions),
         }
-        # Create statistics from local analyzer results
-        local_stats = {
-            "hydrogen_bonds": len(local_analyzer.hydrogen_bonds),
-            "halogen_bonds": len(local_analyzer.halogen_bonds),
-            "pi_interactions": len(local_analyzer.pi_interactions),
-            "total_interactions": len(local_analyzer.hydrogen_bonds)
-            + len(local_analyzer.halogen_bonds)
-            + len(local_analyzer.pi_interactions),
+        # Create statistics from inter-mode analyzer results
+        inter_stats = {
+            "hydrogen_bonds": len(inter_analyzer.hydrogen_bonds),
+            "halogen_bonds": len(inter_analyzer.halogen_bonds),
+            "pi_interactions": len(inter_analyzer.pi_interactions),
+            "total_interactions": len(inter_analyzer.hydrogen_bonds)
+            + len(inter_analyzer.halogen_bonds)
+            + len(inter_analyzer.pi_interactions),
         }
 
-        # Complete mode should generally find more interactions
+        # All mode should generally find more interactions
         assert (
-            complete_stats["total_interactions"] >= local_stats["total_interactions"]
-        ), "Complete mode should find at least as many interactions"
+            all_stats["total_interactions"] >= inter_stats["total_interactions"]
+        ), "All mode should find at least as many interactions"

--- a/tests/integration/test_cli_integration.py
+++ b/tests/integration/test_cli_integration.py
@@ -29,7 +29,7 @@ class TestCLIParameterIntegration:
                 "--hb-angle",
                 "125",
                 "--mode",
-                "complete",
+                "all",
             ]
         )
 
@@ -39,7 +39,7 @@ class TestCLIParameterIntegration:
         # Verify parameter values
         assert params.hb_distance_cutoff == 3.2
         assert params.hb_angle_cutoff == 125.0
-        assert params.analysis_mode == "complete"
+        assert params.analysis_mode == "all"
 
         # Use parameters in core analysis
         analyzer = MolecularInteractionAnalyzer(params)
@@ -50,7 +50,7 @@ class TestCLIParameterIntegration:
         # Verify parameters were applied in analysis
         assert analyzer.parameters.hb_distance_cutoff == 3.2
         assert analyzer.parameters.hb_angle_cutoff == 125.0
-        assert analyzer.parameters.analysis_mode == "complete"
+        assert analyzer.parameters.analysis_mode == "all"
 
         # Verify analysis results
         assert len(analyzer.hydrogen_bonds) >= 0
@@ -123,7 +123,7 @@ class TestCLIParameterIntegration:
                     "h_pi_distance_cutoff": 4.5,
                     "dh_pi_angle_cutoff": 90.0,
                 },
-                "general": {"covalent_cutoff_factor": 0.85, "analysis_mode": "local"},
+                "general": {"covalent_cutoff_factor": 0.85, "analysis_mode": "inter"},
                 "pdb_fixing": {
                     "enabled": False,
                     "method": "openbabel",
@@ -151,7 +151,7 @@ class TestCLIParameterIntegration:
             assert params.whb_distance_cutoff == 3.7
             assert params.whb_angle_cutoff == 145.0
             assert params.whb_donor_acceptor_cutoff == 3.8
-            assert params.analysis_mode == "local"
+            assert params.analysis_mode == "inter"
 
             # Use preset parameters in analysis
             analyzer = MolecularInteractionAnalyzer(params)
@@ -162,7 +162,7 @@ class TestCLIParameterIntegration:
             # Verify preset parameters were applied
             assert analyzer.parameters.hb_distance_cutoff == 3.3
             assert analyzer.parameters.hb_angle_cutoff == 128.0
-            assert analyzer.parameters.analysis_mode == "local"
+            assert analyzer.parameters.analysis_mode == "inter"
 
         except SystemExit:
             pytest.skip("Preset loading not available in test environment")
@@ -186,8 +186,8 @@ class TestCLIAnalysisIntegration:
             # Valid combinations
             ([sample_pdb_file, "--hb-distance", "3.5"], True),
             ([sample_pdb_file, "--hb-angle", "120"], True),
-            ([sample_pdb_file, "--mode", "complete"], True),
-            ([sample_pdb_file, "--mode", "local"], True),
+            ([sample_pdb_file, "--mode", "all"], True),
+            ([sample_pdb_file, "--mode", "inter"], True),
         ]
 
         for args_list, should_work in test_cases:
@@ -309,7 +309,7 @@ class TestCLIPresetIntegration:
                 },
                 "general": {
                     "covalent_cutoff_factor": 0.87,
-                    "analysis_mode": "complete",
+                    "analysis_mode": "all",
                 },
                 "pdb_fixing": {
                     "enabled": True,
@@ -343,7 +343,7 @@ class TestCLIPresetIntegration:
             assert params.pi_distance_cutoff == 4.6
             assert params.pi_angle_cutoff == 88.0
             assert params.covalent_cutoff_factor == 0.87
-            assert params.analysis_mode == "complete"
+            assert params.analysis_mode == "all"
             assert params.fix_pdb_enabled is True
             assert params.fix_pdb_method == "pdbfixer"
             assert params.fix_pdb_add_hydrogens is True
@@ -383,7 +383,7 @@ class TestCLIPresetIntegration:
                 },
                 "general": {
                     "covalent_cutoff_factor": 0.85,
-                    "analysis_mode": "complete",
+                    "analysis_mode": "all",
                 },
                 "pdb_fixing": {
                     "enabled": False,
@@ -505,7 +505,7 @@ class TestCLIValidationIntegration:
         valid_cases = [
             ["test.pdb"],
             ["test.pdb", "--hb-distance", "3.5"],
-            ["test.pdb", "--mode", "complete"],
+            ["test.pdb", "--mode", "all"],
             ["test.pdb", "--fix-pdb", "--fix-method", "openbabel"],
         ]
 

--- a/tests/performance/test_performance_workflows.py
+++ b/tests/performance/test_performance_workflows.py
@@ -186,43 +186,43 @@ class TestLargeStructureParameterPerformance:
 
     def test_analysis_mode_performance_impact(self, large_pdb_file):
         """Test performance impact of analysis modes on large structures."""
-        # Test complete mode
-        complete_params = AnalysisParameters(analysis_mode="all")
-        complete_analyzer = MolecularInteractionAnalyzer(complete_params)
+        # Test all mode
+        all_params = AnalysisParameters(analysis_mode="all")
+        all_analyzer = MolecularInteractionAnalyzer(all_params)
 
-        complete_start = time.time()
-        complete_success = complete_analyzer.analyze_file(large_pdb_file)
-        complete_time = time.time() - complete_start
-        complete_stats = complete_analyzer.get_summary()
+        all_start = time.time()
+        all_success = all_analyzer.analyze_file(large_pdb_file)
+        all_time = time.time() - all_start
+        all_stats = all_analyzer.get_summary()
 
-        assert complete_success
+        assert all_success
 
-        # Test local mode
-        local_params = AnalysisParameters(analysis_mode="inter")
-        local_analyzer = MolecularInteractionAnalyzer(local_params)
+        # Test inter mode
+        inter_params = AnalysisParameters(analysis_mode="inter")
+        inter_analyzer = MolecularInteractionAnalyzer(inter_params)
 
-        local_start = time.time()
-        local_success = local_analyzer.analyze_file(large_pdb_file)
-        local_time = time.time() - local_start
-        local_stats = local_analyzer.get_summary()
+        inter_start = time.time()
+        inter_success = inter_analyzer.analyze_file(large_pdb_file)
+        inter_time = time.time() - inter_start
+        inter_stats = inter_analyzer.get_summary()
 
-        assert local_success
+        assert inter_success
 
-        # Local mode should generally be faster
-        time_speedup = complete_time / local_time
+        # Inter mode should generally be faster
+        time_speedup = all_time / inter_time
 
         print("\nAnalysis Mode Performance (4jsv.pdb):")
-        print("  Complete mode:")
-        print(f"    Time: {complete_time:.2f}s")
-        print(f"    Interactions: {complete_stats['total_interactions']}")
-        print("  Local mode:")
-        print(f"    Time: {local_time:.2f}s")
-        print(f"    Interactions: {local_stats['total_interactions']}")
+        print("  All mode:")
+        print(f"    Time: {all_time:.2f}s")
+        print(f"    Interactions: {all_stats['total_interactions']}")
+        print("  Inter mode:")
+        print(f"    Time: {inter_time:.2f}s")
+        print(f"    Interactions: {inter_stats['total_interactions']}")
         print(f"  Speedup: {time_speedup:.2f}x")
 
         # Both should complete in reasonable time
-        assert complete_time < 300.0, "Complete mode should finish within 5 minutes"
-        assert local_time < 200.0, "Local mode should finish within 3.5 minutes"
+        assert all_time < 300.0, "All mode should finish within 5 minutes"
+        assert inter_time < 200.0, "Inter mode should finish within 3.5 minutes"
 
     def test_parameter_strictness_performance_impact(self, large_pdb_file):
         """Test performance impact of parameter strictness."""

--- a/tests/performance/test_performance_workflows.py
+++ b/tests/performance/test_performance_workflows.py
@@ -187,7 +187,7 @@ class TestLargeStructureParameterPerformance:
     def test_analysis_mode_performance_impact(self, large_pdb_file):
         """Test performance impact of analysis modes on large structures."""
         # Test complete mode
-        complete_params = AnalysisParameters(analysis_mode="complete")
+        complete_params = AnalysisParameters(analysis_mode="all")
         complete_analyzer = MolecularInteractionAnalyzer(complete_params)
 
         complete_start = time.time()
@@ -198,7 +198,7 @@ class TestLargeStructureParameterPerformance:
         assert complete_success
 
         # Test local mode
-        local_params = AnalysisParameters(analysis_mode="local")
+        local_params = AnalysisParameters(analysis_mode="inter")
         local_analyzer = MolecularInteractionAnalyzer(local_params)
 
         local_start = time.time()
@@ -228,7 +228,7 @@ class TestLargeStructureParameterPerformance:
         """Test performance impact of parameter strictness."""
         # Strict parameters (fewer interactions to compute)
         strict_params = AnalysisParameters(
-            hb_distance_cutoff=2.5, hb_angle_cutoff=150.0, analysis_mode="local"
+            hb_distance_cutoff=2.5, hb_angle_cutoff=150.0, analysis_mode="inter"
         )
         strict_analyzer = MolecularInteractionAnalyzer(strict_params)
 
@@ -241,7 +241,7 @@ class TestLargeStructureParameterPerformance:
 
         # Permissive parameters (more interactions to compute)
         permissive_params = AnalysisParameters(
-            hb_distance_cutoff=4.0, hb_angle_cutoff=100.0, analysis_mode="complete"
+            hb_distance_cutoff=4.0, hb_angle_cutoff=100.0, analysis_mode="all"
         )
         permissive_analyzer = MolecularInteractionAnalyzer(permissive_params)
 

--- a/tests/unit/test_analysis_mode_semantics.py
+++ b/tests/unit/test_analysis_mode_semantics.py
@@ -1,0 +1,235 @@
+"""Unit tests for interaction inclusion mode semantics."""
+
+import math
+
+import pytest
+
+from hbat.constants import RING_ATOMS_FOR_RESIDUES_WITH_AROMATIC_RINGS
+from hbat.constants.parameters import AnalysisParameters
+from hbat.core.np_analyzer import NPMolecularInteractionAnalyzer
+from hbat.core.np_vector import NPVec3D
+from hbat.core.structure import Atom, Bond, Residue
+
+
+def make_atom(
+    serial: int,
+    name: str,
+    element: str,
+    coords: tuple[float, float, float],
+    res_name: str = "PHE",
+    res_seq: int = 1,
+) -> Atom:
+    """Create a minimal atom for detector tests."""
+    return Atom(
+        serial=serial,
+        name=name,
+        alt_loc="",
+        res_name=res_name,
+        chain_id="A",
+        res_seq=res_seq,
+        i_code="",
+        coords=NPVec3D(*coords),
+        occupancy=1.0,
+        temp_factor=20.0,
+        element=element,
+        charge="",
+        record_type="ATOM",
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("mode", "same_residue", "expected"),
+    [
+        ("inter", True, True),
+        ("inter", False, False),
+        ("all", True, False),
+        ("all", False, False),
+    ],
+)
+def test_same_residue_skip_policy(mode, same_residue, expected):
+    """The shared policy skips same-residue candidates only in inter mode."""
+    analyzer = NPMolecularInteractionAnalyzer(AnalysisParameters(analysis_mode=mode))
+    residue1 = ("A", 1, "PHE")
+    residue2 = residue1 if same_residue else ("A", 2, "TYR")
+
+    assert analyzer._should_skip_same_residue(residue1, residue2) is expected
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(("mode", "expected_count"), [("inter", 0), ("all", 1)])
+def test_hydrogen_bond_detector_respects_analysis_mode(
+    monkeypatch, mode, expected_count
+):
+    """Hydrogen bond detection applies the mode policy to same-residue pairs."""
+    analyzer = NPMolecularInteractionAnalyzer(AnalysisParameters(analysis_mode=mode))
+    donor = make_atom(1, "N", "N", (0.0, 0.0, 0.0))
+    hydrogen = make_atom(2, "H", "H", (1.0, 0.0, 0.0))
+    acceptor = make_atom(3, "O", "O", (2.5, 0.0, 0.0))
+    analyzer.parser.atoms = [donor, hydrogen, acceptor]
+    analyzer._prepare_vectorized_data()
+    monkeypatch.setattr(
+        analyzer,
+        "_get_hydrogen_bond_donors",
+        lambda: [(donor, hydrogen, 0, 1)],
+    )
+
+    analyzer._find_hydrogen_bonds_vectorized()
+
+    assert len(analyzer.hydrogen_bonds) == expected_count
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(("mode", "expected_count"), [("inter", 0), ("all", 1)])
+def test_halogen_bond_detector_respects_analysis_mode(mode, expected_count):
+    """Halogen bond detection applies the mode policy to same-residue pairs."""
+    analyzer = NPMolecularInteractionAnalyzer(AnalysisParameters(analysis_mode=mode))
+    carbon = make_atom(1, "C", "C", (0.0, 0.0, 0.0))
+    halogen = make_atom(2, "CL", "CL", (1.0, 0.0, 0.0))
+    acceptor = make_atom(3, "O", "O", (3.0, 0.0, 0.0))
+    analyzer.parser.atoms = [carbon, halogen, acceptor]
+    analyzer.parser.bonds = [Bond(carbon.serial, halogen.serial)]
+    analyzer._prepare_vectorized_data()
+
+    analyzer._find_halogen_bonds_vectorized()
+
+    assert len(analyzer.halogen_bonds) == expected_count
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(("mode", "expected_count"), [("inter", 0), ("all", 1)])
+def test_pi_detector_respects_analysis_mode(monkeypatch, mode, expected_count):
+    """Pi detection applies the mode policy to same-residue candidates."""
+    analyzer = NPMolecularInteractionAnalyzer(AnalysisParameters(analysis_mode=mode))
+    ring_names = RING_ATOMS_FOR_RESIDUES_WITH_AROMATIC_RINGS["PHE"]
+    ring_coords = [
+        (1.0, 0.0, 0.0),
+        (0.5, 0.866, 0.0),
+        (-0.5, 0.866, 0.0),
+        (-1.0, 0.0, 0.0),
+        (-0.5, -0.866, 0.0),
+        (0.5, -0.866, 0.0),
+    ]
+    ring_atoms = [
+        make_atom(serial, name, "C", coords)
+        for serial, (name, coords) in enumerate(
+            zip(ring_names[:6], ring_coords), start=1
+        )
+    ]
+    donor = make_atom(20, "N", "N", (0.0, 0.0, 4.0))
+    hydrogen = make_atom(21, "H", "H", (0.0, 0.0, 3.0))
+    residue = Residue("PHE", "A", 1, "", ring_atoms + [donor, hydrogen])
+    analyzer.parser.atoms = residue.atoms
+    analyzer.parser.residues = {"A:PHE:1": residue}
+    analyzer._prepare_vectorized_data()
+    monkeypatch.setattr(
+        analyzer, "_get_pi_interaction_pairs", lambda: [(donor, hydrogen)]
+    )
+
+    analyzer._find_pi_interactions_vectorized()
+
+    assert len(analyzer.pi_interactions) == expected_count
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("legacy_mode", "canonical_mode", "skips_same_residue"),
+    [("local", "inter", True), ("complete", "all", False)],
+)
+def test_canonical_modes_preserve_legacy_semantics(
+    legacy_mode, canonical_mode, skips_same_residue
+):
+    """Record the intended semantic mapping for the breaking mode rename."""
+    analyzer = NPMolecularInteractionAnalyzer(
+        AnalysisParameters(analysis_mode=canonical_mode)
+    )
+    residue = ("A", 1, "PHE")
+
+    assert analyzer._should_skip_same_residue(residue, residue) is skips_same_residue, (
+        f"{canonical_mode} must preserve the previous {legacy_mode} behavior"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(("mode", "expected_count"), [("inter", 0), ("all", 1)])
+def test_pi_pi_detector_respects_analysis_mode(mode, expected_count):
+    """Pi-pi detection applies the mode policy to same-residue ring pairs."""
+    analyzer = NPMolecularInteractionAnalyzer(AnalysisParameters(analysis_mode=mode))
+    ring_names = RING_ATOMS_FOR_RESIDUES_WITH_AROMATIC_RINGS["PHE"]
+    ring_coords = [
+        (1.0, 0.0, 0.0),
+        (0.5, 0.866, 0.0),
+        (-0.5, 0.866, 0.0),
+        (-1.0, 0.0, 0.0),
+        (-0.5, -0.866, 0.0),
+        (0.5, -0.866, 0.0),
+    ]
+    ring_atoms = [
+        make_atom(serial, name, "C", coords)
+        for serial, (name, coords) in enumerate(
+            zip(ring_names[:6], ring_coords), start=1
+        )
+    ]
+    residue = Residue("PHE", "A", 1, "", ring_atoms)
+    # Duplicate values exercise the same-residue detector branch directly.
+    analyzer.parser.residues = {"first": residue, "second": residue}
+
+    analyzer._find_pi_pi_interactions_vectorized()
+
+    assert len(analyzer.pi_pi_interactions) == expected_count
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(("mode", "expected_count"), [("inter", 0), ("all", 2)])
+def test_carbonyl_detector_respects_analysis_mode(monkeypatch, mode, expected_count):
+    """Carbonyl detection includes same-residue candidates only in all mode."""
+    analyzer = NPMolecularInteractionAnalyzer(AnalysisParameters(analysis_mode=mode))
+    analyzer.parser.atoms = [
+        make_atom(1, "C", "C", (0.0, 0.0, 0.0), "ASP"),
+        make_atom(2, "O", "O", (1.2, 0.0, 0.0), "ASP"),
+        make_atom(3, "CG", "C", (4.2, 0.0, 0.0), "ASP"),
+        make_atom(4, "OD1", "O", (3.0, 0.0, 0.0), "ASP"),
+    ]
+    monkeypatch.setattr(
+        analyzer,
+        "_identify_carbonyl_groups",
+        lambda: [(0, 1, True, "ASP1"), (2, 3, False, "ASP1")],
+    )
+    monkeypatch.setattr(
+        "hbat.core.np_analyzer.batch_angle_between",
+        lambda *_args: math.radians(107.0),
+    )
+
+    analyzer._find_carbonyl_interactions_vectorized()
+
+    assert len(analyzer.carbonyl_interactions) == expected_count
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(("mode", "expected_count"), [("inter", 0), ("all", 1)])
+def test_n_pi_detector_respects_analysis_mode(mode, expected_count):
+    """n-pi detection includes same-residue candidates only in all mode."""
+    analyzer = NPMolecularInteractionAnalyzer(AnalysisParameters(analysis_mode=mode))
+    ring_names = RING_ATOMS_FOR_RESIDUES_WITH_AROMATIC_RINGS["PHE"]
+    ring_coords = [
+        (1.0, 0.0, 0.0),
+        (0.5, 0.866, 0.0),
+        (-0.5, 0.866, 0.0),
+        (-1.0, 0.0, 0.0),
+        (-0.5, -0.866, 0.0),
+        (0.5, -0.866, 0.0),
+    ]
+    ring_atoms = [
+        make_atom(serial, name, "C", coords)
+        for serial, (name, coords) in enumerate(
+            zip(ring_names[:6], ring_coords), start=1
+        )
+    ]
+    donor = make_atom(20, "O", "O", (3.2, 0.0, 0.0))
+    residue = Residue("PHE", "A", 1, "", ring_atoms + [donor])
+    analyzer.parser.atoms = residue.atoms
+    analyzer.parser.residues = {"A:PHE:1": residue}
+
+    analyzer._find_n_pi_interactions_vectorized()
+
+    assert len(analyzer.n_pi_interactions) == expected_count

--- a/tests/unit/test_cli_parsing.py
+++ b/tests/unit/test_cli_parsing.py
@@ -42,12 +42,12 @@ class TestCLIArgumentParsing:
         parser = create_parser()
 
         args = parser.parse_args(
-            ["test.pdb", "--hb-distance", "3.0", "--hb-angle", "130", "--mode", "local"]
+            ["test.pdb", "--hb-distance", "3.0", "--hb-angle", "130", "--mode", "inter"]
         )
 
         assert args.hb_distance == 3.0
         assert args.hb_angle == 130.0
-        assert args.mode == "local"
+        assert args.mode == "inter"
 
     def test_weak_hydrogen_bond_arguments(self):
         """Test weak hydrogen bond parameter arguments."""
@@ -262,13 +262,13 @@ class TestParameterConversion:
         """Test loading custom parameters."""
         parser = create_parser()
         args = parser.parse_args(
-            ["test.pdb", "--hb-distance", "3.2", "--hb-angle", "140", "--mode", "local"]
+            ["test.pdb", "--hb-distance", "3.2", "--hb-angle", "140", "--mode", "inter"]
         )
 
         params = load_parameters_from_args(args)
         assert params.hb_distance_cutoff == 3.2
         assert params.hb_angle_cutoff == 140.0
-        assert params.analysis_mode == "local"
+        assert params.analysis_mode == "inter"
 
     def test_weak_hydrogen_bond_parameter_loading(self):
         """Test loading weak hydrogen bond parameters."""
@@ -553,11 +553,11 @@ class TestArgumentValidation:
         parser = create_parser()
 
         # Test valid choice
-        args = parser.parse_args(["test.pdb", "--mode", "local"])
-        assert args.mode == "local"
+        args = parser.parse_args(["test.pdb", "--mode", "inter"])
+        assert args.mode == "inter"
 
-        args = parser.parse_args(["test.pdb", "--mode", "complete"])
-        assert args.mode == "complete"
+        args = parser.parse_args(["test.pdb", "--mode", "all"])
+        assert args.mode == "all"
 
         args = parser.parse_args(["test.pdb", "--fix-method", "openbabel"])
         assert args.fix_method == "openbabel"
@@ -570,6 +570,13 @@ class TestArgumentValidation:
         parser = create_parser()
         with pytest.raises(SystemExit):
             parser.parse_args(["test.pdb", "--mode", "invalid_mode"])
+
+    @pytest.mark.parametrize("legacy_mode", ["local", "complete"])
+    def test_legacy_mode_choices_are_rejected(self, legacy_mode):
+        """Test that removed mode choices are rejected by the CLI."""
+        parser = create_parser()
+        with pytest.raises(SystemExit):
+            parser.parse_args(["test.pdb", "--mode", legacy_mode])
 
     def test_invalid_fix_method_choice(self):
         """Test that invalid fix method choice raises error."""

--- a/tests/unit/test_gui_components.py
+++ b/tests/unit/test_gui_components.py
@@ -105,7 +105,7 @@ class TestDialogLogic:
                 },
                 "general": {
                     "covalent_cutoff_factor": 0.85,
-                    "analysis_mode": "complete",
+                    "analysis_mode": "all",
                 },
                 "pdb_fixing": {
                     "enabled": False,
@@ -231,7 +231,7 @@ class TestAnalysisIntegration:
 
             # Test creating analyzer with GUI parameters
             params = AnalysisParameters(
-                hb_distance_cutoff=3.2, analysis_mode="complete"
+                hb_distance_cutoff=3.2, analysis_mode="all"
             )
 
             analyzer = NPMolecularInteractionAnalyzer(params)
@@ -259,7 +259,7 @@ class TestDialogDataStructures:
                 xb_angle_cutoff=120.0,
                 pi_distance_cutoff=4.5,
                 pi_angle_cutoff=90.0,
-                analysis_mode="complete",
+                analysis_mode="all",
             )
 
             # Verify all geometry parameters exist
@@ -401,7 +401,7 @@ class TestGeometryCutoffsDialogLogic:
                 hb_distance_cutoff=3.2,
                 hb_angle_cutoff=125.0,
                 whb_distance_cutoff=3.8,
-                analysis_mode="local",
+                analysis_mode="inter",
             )
 
             setter.set_parameters(test_params)
@@ -410,7 +410,7 @@ class TestGeometryCutoffsDialogLogic:
             assert setter._param_values["hb_distance"] == 3.2
             assert setter._param_values["hb_angle"] == 125.0
             assert setter._param_values["whb_distance"] == 3.8
-            assert setter._param_values["analysis_mode"] == "local"
+            assert setter._param_values["analysis_mode"] == "inter"
 
         except ImportError as e:
             pytest.skip(f"AnalysisParameters not available: {e}")
@@ -479,7 +479,7 @@ class TestGeometryCutoffsDialogLogic:
                         hb_distance_cutoff=self._param_values.get("hb_distance", 3.5),
                         hb_angle_cutoff=self._param_values.get("hb_angle", 120.0),
                         analysis_mode=self._param_values.get(
-                            "analysis_mode", "complete"
+                            "analysis_mode", "all"
                         ),
                     )
 
@@ -488,7 +488,7 @@ class TestGeometryCutoffsDialogLogic:
 
             # 1. Set initial parameters
             initial_params = AnalysisParameters(
-                hb_distance_cutoff=3.2, analysis_mode="local"
+                hb_distance_cutoff=3.2, analysis_mode="inter"
             )
             dialog.set_parameters(initial_params)
 
@@ -501,7 +501,7 @@ class TestGeometryCutoffsDialogLogic:
             # Verify parameters were preserved and modified correctly
             assert final_params.hb_distance_cutoff == 3.8  # Modified
             assert final_params.hb_angle_cutoff == 130.0  # Modified
-            assert final_params.analysis_mode == "local"  # Preserved from initial
+            assert final_params.analysis_mode == "inter"  # Preserved from initial
 
         except ImportError as e:
             pytest.skip(f"AnalysisParameters not available: {e}")

--- a/tests/unit/test_parameters.py
+++ b/tests/unit/test_parameters.py
@@ -43,7 +43,7 @@ class TestAnalysisParametersCreation:
         assert params.pi_sh_distance_cutoff > 0
         assert params.pi_sh_angle_cutoff > 0
         assert params.covalent_cutoff_factor > 0
-        assert params.analysis_mode in ["complete", "local"]
+        assert params.analysis_mode in ["all", "inter"]
 
         # Test PDB fixing defaults
         assert isinstance(params.fix_pdb_enabled, bool)
@@ -169,10 +169,10 @@ class TestAnalysisParametersCustomization:
 
     def test_custom_general_parameters(self):
         """Test setting custom general parameters."""
-        params = AnalysisParameters(covalent_cutoff_factor=0.9, analysis_mode="local")
+        params = AnalysisParameters(covalent_cutoff_factor=0.9, analysis_mode="inter")
 
         assert params.covalent_cutoff_factor == 0.9
-        assert params.analysis_mode == "local"
+        assert params.analysis_mode == "inter"
 
     def test_custom_pdb_fixing_parameters(self):
         """Test setting custom PDB fixing parameters."""
@@ -201,11 +201,20 @@ class TestAnalysisParametersValidation:
 
     def test_valid_analysis_modes(self):
         """Test valid analysis mode values."""
-        valid_modes = ["complete", "local"]
+        valid_modes = ["inter", "all"]
 
         for mode in valid_modes:
             params = AnalysisParameters(analysis_mode=mode)
             assert params.analysis_mode == mode
+
+    @pytest.mark.parametrize("legacy_mode", ["local", "complete"])
+    def test_legacy_analysis_modes_are_rejected(self, legacy_mode):
+        """Test that removed analysis mode values fail validation."""
+        params = AnalysisParameters(analysis_mode=legacy_mode)
+
+        errors = params.validate()
+
+        assert any("Analysis mode must be one of: inter, all" in error for error in errors)
 
     def test_valid_pdb_fixing_methods(self):
         """Test valid PDB fixing method values."""
@@ -351,7 +360,7 @@ class TestAnalysisParametersCombinations:
             pi_distance_cutoff=3.8,
             pi_angle_cutoff=100.0,
             covalent_cutoff_factor=0.8,
-            analysis_mode="local",
+            analysis_mode="inter",
         )
 
         # Verify all values are set correctly
@@ -366,7 +375,7 @@ class TestAnalysisParametersCombinations:
         assert params.pi_distance_cutoff == 3.8
         assert params.pi_angle_cutoff == 100.0
         assert params.covalent_cutoff_factor == 0.8
-        assert params.analysis_mode == "local"
+        assert params.analysis_mode == "inter"
 
     def test_permissive_parameters_combination(self):
         """Test permissive analysis parameter combination."""
@@ -382,7 +391,7 @@ class TestAnalysisParametersCombinations:
             pi_distance_cutoff=5.0,
             pi_angle_cutoff=70.0,
             covalent_cutoff_factor=1.0,
-            analysis_mode="complete",
+            analysis_mode="all",
         )
 
         # Verify all values are set correctly
@@ -397,7 +406,7 @@ class TestAnalysisParametersCombinations:
         assert params.pi_distance_cutoff == 5.0
         assert params.pi_angle_cutoff == 70.0
         assert params.covalent_cutoff_factor == 1.0
-        assert params.analysis_mode == "complete"
+        assert params.analysis_mode == "all"
 
     def test_pdb_fixing_enabled_combination(self):
         """Test parameter combination with PDB fixing enabled."""
@@ -407,7 +416,7 @@ class TestAnalysisParametersCombinations:
             fix_pdb_method="openbabel",
             fix_pdb_add_hydrogens=True,
             fix_pdb_add_heavy_atoms=False,
-            analysis_mode="complete",
+            analysis_mode="all",
         )
 
         assert params.hb_distance_cutoff == 3.5
@@ -415,7 +424,7 @@ class TestAnalysisParametersCombinations:
         assert params.fix_pdb_method == "openbabel"
         assert params.fix_pdb_add_hydrogens is True
         assert params.fix_pdb_add_heavy_atoms is False
-        assert params.analysis_mode == "complete"
+        assert params.analysis_mode == "all"
 
     def test_pdbfixer_specific_combination(self):
         """Test parameter combination specific to PDBFixer."""
@@ -445,11 +454,11 @@ class TestAnalysisParametersEquality:
     def test_parameters_equality_same_values(self):
         """Test equality of parameters with same values."""
         params1 = AnalysisParameters(
-            hb_distance_cutoff=3.5, hb_angle_cutoff=120.0, analysis_mode="complete"
+            hb_distance_cutoff=3.5, hb_angle_cutoff=120.0, analysis_mode="all"
         )
 
         params2 = AnalysisParameters(
-            hb_distance_cutoff=3.5, hb_angle_cutoff=120.0, analysis_mode="complete"
+            hb_distance_cutoff=3.5, hb_angle_cutoff=120.0, analysis_mode="all"
         )
 
         # Test that parameters can be compared (behavior depends on implementation)
@@ -476,7 +485,7 @@ class TestAnalysisParametersStringRepresentation:
     def test_parameters_string_representation(self):
         """Test that parameters can be converted to string."""
         params = AnalysisParameters(
-            hb_distance_cutoff=3.5, hb_angle_cutoff=120.0, analysis_mode="complete"
+            hb_distance_cutoff=3.5, hb_angle_cutoff=120.0, analysis_mode="all"
         )
 
         # Test that string conversion works (exact format depends on implementation)

--- a/tests/unit/test_preset_validation.py
+++ b/tests/unit/test_preset_validation.py
@@ -1,0 +1,77 @@
+"""Unit tests for preset validation boundaries."""
+
+import json
+
+import pytest
+
+from hbat.cli.main import load_preset_file
+from hbat.constants.parameters import AnalysisParameters
+from hbat.gui.geometry_cutoffs_dialog import GeometryCutoffsDialog
+from hbat.gui.main_window import MainWindow
+
+
+def preset_with_mode(mode: str) -> dict:
+    """Create a minimal preset using the requested analysis mode."""
+    return {"parameters": {"general": {"analysis_mode": mode}}}
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("legacy_mode", ["local", "complete"])
+def test_cli_rejects_legacy_preset_modes(tmp_path, capsys, legacy_mode):
+    """CLI preset loading rejects removed analysis modes with a useful error."""
+    preset_path = tmp_path / "legacy.hbat"
+    preset_path.write_text(json.dumps(preset_with_mode(legacy_mode)))
+
+    with pytest.raises(SystemExit):
+        load_preset_file(str(preset_path))
+
+    error = capsys.readouterr().err
+    assert "Invalid preset parameters" in error
+    assert "Analysis mode must be one of: inter, all" in error
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("legacy_mode", ["local", "complete"])
+def test_main_window_rejects_legacy_preset_modes(monkeypatch, legacy_mode):
+    """Desktop preset loading rejects old modes without replacing the session."""
+    window = MainWindow.__new__(MainWindow)
+    original_params = AnalysisParameters(analysis_mode="all")
+    window.session_parameters = original_params
+    errors = []
+    monkeypatch.setattr(
+        "hbat.gui.main_window.messagebox.showerror",
+        lambda title, message: errors.append((title, message)),
+    )
+
+    applied = window._apply_preset_to_session(preset_with_mode(legacy_mode))
+
+    assert applied is False
+    assert window.session_parameters is original_params
+    assert errors[0][0] == "Invalid Preset"
+    assert "Analysis mode must be one of: inter, all" in errors[0][1]
+
+
+@pytest.mark.unit
+def test_main_window_applies_valid_preset_mode():
+    """Desktop preset loading applies valid canonical analysis modes."""
+    window = MainWindow.__new__(MainWindow)
+    window.session_parameters = AnalysisParameters(analysis_mode="inter")
+
+    applied = window._apply_preset_to_session(preset_with_mode("all"))
+
+    assert applied is True
+    assert window.session_parameters.analysis_mode == "all"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("legacy_mode", ["local", "complete"])
+def test_geometry_dialog_rejects_legacy_preset_modes(legacy_mode):
+    """Geometry preset loading rejects old modes and restores prior values."""
+    dialog = GeometryCutoffsDialog.__new__(GeometryCutoffsDialog)
+    dialog._vars = {}
+    dialog._param_values = {"analysis_mode": "all"}
+
+    with pytest.raises(ValueError, match="Analysis mode must be one of: inter, all"):
+        dialog._apply_preset_data(preset_with_mode(legacy_mode))
+
+    assert dialog._param_values["analysis_mode"] == "all"


### PR DESCRIPTION
## Release Notes: Analysis Mode Semantics

### Breaking Changes

Analysis modes have been renamed to clearly describe interaction inclusion behavior:

| Previous value | New value | Behavior |
|---|---|---|
| `local` | `inter` | Includes interactions between different residues only |
| `complete` | `all` | Includes both inter-residue and intra-residue interactions |

The legacy `local` and `complete` values are no longer accepted.

### Changed

- Changed the default `analysis_mode` from `local` to `inter`.
- Updated CLI, desktop GUI, web UI, presets, examples, and documentation to use `inter` and `all`.
- Applied analysis-mode filtering consistently across:
  - Hydrogen bonds
  - Halogen bonds
  - Pi interactions
  - Pi-pi interactions
  - Carbonyl interactions
  - n→π interactions
- Centralized same-residue filtering logic in the core analyzer.
- Added parameter validation when constructing an analyzer.
- Added preset validation for CLI and desktop GUI workflows.
- Invalid presets are rejected without replacing the current GUI parameters.

### Migration

Update API calls and preset files:

```python
# Before
AnalysisParameters(analysis_mode="local")
AnalysisParameters(analysis_mode="complete")

# After
AnalysisParameters(analysis_mode="inter")
AnalysisParameters(analysis_mode="all")
```

Update CLI commands:

```bash
# Before
hbat input.pdb --mode local

# After
hbat input.pdb --mode inter
```

### Testing

- Added direct behavioral tests for every interaction detector under both modes.
- Added tests confirming legacy values are rejected through API, CLI, and preset-loading paths.
- Added tests confirming canonical modes preserve the intended legacy semantics.
- Renamed stale mode terminology in performance tests.
- Focused parameter, CLI, preset, and mode-semantic tests pass.